### PR TITLE
fix(module): incorrect width and height values for optimized images

### DIFF
--- a/src/runtime/fields/standard/image.field.ts
+++ b/src/runtime/fields/standard/image.field.ts
@@ -149,8 +149,8 @@ export default defineField({
               if (optimizedImage.success) {
                 sources.push({
                   srcset: optimizedImage.src,
-                  width: source.width ?? upload.width,
-                  height: source.height ?? upload.height,
+                  width: optimizedImage.width,
+                  height: optimizedImage.height,
                   media: source.media ?? null,
                   type: source.format === 'jpeg' ? 'image/jpeg' : `image/${source.format}`,
                 })


### PR DESCRIPTION
When adding image sources with missing width or height, the missing dimension is suppose to auto scaled by sharp. But the source is falling back to the dimension of the original image. 

For instance, uploading a image (1920x1080) with the following config, leads to a correctly resized image (1280x720) but a wrong image source size of 1280x1080

```ts
...
image: imageField({
    description: 'The image to display',
    sources: [
        { format: 'webp', width: 1280 },
    ],
}),
...
```
By returning the width & height from the sharp instance the image source dimensions are correct.
