### PR TITLE
Drag & drop into nested blocks causes error "Cannot read properties of undefined"

### DIFF
--- a/src/runtime/components/misc/FieldLayout.vue
+++ b/src/runtime/components/misc/FieldLayout.vue
@@ -57,7 +57,7 @@
         <div
           v-if="
             item?.type === 'field' &&
-            !fieldsDeclaration[item.fieldName].additional?.hidden &&
+            !fieldsDeclaration[item.fieldName]?.additional?.hidden &&
             resolvedConditionalLogic[keyPrefix + item.fieldName] &&
             (keyPrefix + item.fieldName !== 'translations' ||
               (collection.mode === 'multi' && record.id && collection.translatable && supportedLanguages.length > 1))


### PR DESCRIPTION
When drag & dropping a block into another the `FieldLayout.vue` component breaks and causes an error.
[Screencast from 2024-07-28 20-26-54.webm](https://github.com/user-attachments/assets/b00e81ed-a58f-463c-a68a-09d3c020560b)

![image](https://github.com/user-attachments/assets/6fc168a2-d296-4143-976a-fb949ed59895)

By adding the missing optional chaining the bug seems to be fixed.