### PR TITLE
fix: added missing comma in dashboard page generator

### DIFF
--- a/src/runtime/dashboard/dashboard.generator.ts
+++ b/src/runtime/dashboard/dashboard.generator.ts
@@ -41,7 +41,7 @@ export function generateDashboardPages(
   tsDashboard.newDecl(`export const dashboardPageComponentImports = {`)
   for (const { definition, source } of dashboardPagesArray) {
     tsDashboard.newLine(
-      `'${definition.path}': () => import('${relativeDotPruviousImport(resolveAppPath(definition.vueComponent))}')`,
+      `'${definition.path}': () => import('${relativeDotPruviousImport(resolveAppPath(definition.vueComponent))}'),`,
     )
   }
   tsDashboard.newLine(`}`)


### PR DESCRIPTION
Hey!
When adding multiple custom dashboard pages I encounter an error where commas at the end of imports aren't being generated.

![image](https://github.com/user-attachments/assets/8e22e189-8808-482f-80e2-cdeac15e5a73)

I was able to test it via the playground in the repo