### PR TITLE
Add Dockerfile and basic build/usage guide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,47 @@
+# Use the latest Node.js image as the base
 FROM node:current as base
 LABEL authors="pruvious"
 
-# Create destination directory
+# Create and set the working directory
 RUN mkdir -p /app
 WORKDIR /app
 
+# Set the environment to production
 ENV NODE_ENV=production
 
-# Build - Build nuxt app
+# Build stage
 FROM base as build
 
+# Install necessary tools for the build process
 RUN apt-get update -y && apt-get install -y openssl git
 
+# Copy package.json and package-lock.json (if available)
 COPY --link package.json package-lock.json ./
 
+# Install all dependencies, including devDependencies
+# --production=false ensures devDependencies are installed
+# --arch=x64 specifies the architecture
 RUN npm install --production=false --arch=x64
 
+# Copy the rest of the application code
 COPY --link . .
 
-# Build nuxt
+# Build the Nuxt.js application
 RUN npm run build
 
-# Run - This is the final stage that get's deployed
+# Production stage
 FROM base
 WORKDIR /app
 
+# Set the PORT environment variable
 ENV PORT=$PORT
 ENV NODE_ENV=production
 
+# Copy the built application from the build stage
 COPY --from=build /app/.output /app/.output
 
-# Optional, only needed if you rely on unbundled dependencies
+# Optional: Uncomment if you need unbundled dependencies
 # COPY --from=build /src/node_modules /src/node_modules
 
+# Command to run the application
 CMD [ "node", ".output/server/index.mjs" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ COPY --link package.json package-lock.json ./
 
 # Install all dependencies, including devDependencies
 # --production=false ensures devDependencies are installed
-# --arch=x64 specifies the architecture
+# --arch=x64 specifies the architecture - this has been added to ensure the build output runs as expected if built on non x64 processors but has to run on an x64 server
+# If you plan on running pruvious on an arm or non x64 based host, make sure to remove this argument!
 RUN npm install --production=false --arch=x64
 
 # Copy the rest of the application code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:current as base
+LABEL authors="pruvious"
+
+# Create destination directory
+RUN mkdir -p /app
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Build - Build nuxt app
+FROM base as build
+
+RUN apt-get update -y && apt-get install -y openssl git
+
+COPY --link package.json package-lock.json ./
+
+RUN npm install --production=false --arch=x64
+
+COPY --link . .
+
+# Build nuxt
+RUN npm run build
+
+# Run - This is the final stage that get's deployed
+FROM base
+WORKDIR /app
+
+ENV PORT=$PORT
+ENV NODE_ENV=production
+
+COPY --from=build /app/.output /app/.output
+
+# Optional, only needed if you rely on unbundled dependencies
+# COPY --from=build /src/node_modules /src/node_modules
+
+CMD [ "node", ".output/server/index.mjs" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,60 @@
+# Docker deployment guide
+
+This guide will give you a quick overview and general guidelines on how to deploy your pruvious instance using docker.
+
+The supplied Dockerfile builds a production container you can use to run pruvious on most container runtimes.
+As of the time of writing, Docker, Docker Swarm and Kubernetes (containerd) have been tested.
+
+Some basic knowledge of docker and docker-compose is expected throughout this guide.
+If you want to learn more about docker and compose feel free to check out the docker documentation at https://docs.docker.com/get-started/docker-overview/.
+
+
+# 1. Building the docker image
+
+## Prerequisites
+
+    Ensure that you have Docker installed on your machine.
+
+### Building the image
+
+To build the Docker image, run the following command in the root of your project:
+
+```bash
+docker build -t pruvious-app .
+```
+This will create a Docker image with the tag `pruvious-app` on your local machine. You can change this tag if you like, but make sure to change it in the supplied docker-compose files.
+If you plan on running the image on another machine than the one you built it on, please consider pushing the image to a container registry like docker hub.
+
+# 2. Deploying via Portainer/Docker-Compose
+
+The supplied docker-compose files in the `/docker` directory are supposed to be a starting point to get you up and running with your image.
+
+## Option 1: Local Build (easy way)
+Have docker-compose automatically build an image from your current repository, and use that in the deployment.
+This is the easiest way to deploy pruvious with a database on a system.
+
+### Step 1: Copy /docker/docker-compose.yml to /
+Copy the docker-compose.yml to your repository root (run from the root directory of you repository):
+```bash
+cp ./docker/docker-compose.yml ./
+```
+
+### Step 2: Run docker-compose to build and deploy
+Make sure you are using compose v2 when running this
+```bash
+docker compose up --build
+```
+If above command does not work, you might still be using compose v1. Run the following instead:
+```bash
+docker-compose up --build
+```
+
+### Congrats
+You should now see a pruvious instance with all of your blocks on port 3000 :)
+
+
+## Option 2: Docker Swarm with traefik (hard)
+See `/docker/docker-compose.traefik.yml`
+
+This option mainly exists to showcase how we (onesrv.net) have deployed pruvious in production and provide a starting point for people who are looking to deploy in a similar environment.
+If you are reading this, you probably know your fair share of docker and other tools. Going into detail on swarm, traefik and portainer would be too much for here.

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,12 @@
 
 By: [@flexusma](https://github.com/Flexusma)
 
+> [!WARNING]
+> If you just want to deploy Pruvious on a single system, the recommended way to do so is using the Pruvious CLI.
+> The CLI allows you to deploy your local Instance to a remote server using SSH while also including database data.
+> More information on Pruvious CLI can be found here: https://pruvious.com/docs/deployment.
+
+
 This guide provides a quick overview and general guidelines on how to deploy your Pruvious instance using Docker.
 
 The supplied Dockerfile builds a production container you can use to run Pruvious on most container runtimes.
@@ -36,7 +42,8 @@ The supplied docker-compose files in the `/docker` directory are intended to be 
 ### Option 1: Local Build (easy way)
 
 Have docker-compose automatically build an image from your current repository and use that in the deployment.
-This is the easiest way to deploy Pruvious with a database on a single system.
+This is the easiest way to deploy Pruvious with a database on a single system, if you want to use docker.
+
 
 #### Step 1: Copy /docker/docker-compose.yml to /
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,19 +1,21 @@
 # Docker deployment guide
 
-This guide will give you a quick overview and general guidelines on how to deploy your pruvious instance using docker.
+By: [@flexusma](https://github.com/Flexusma)
 
-The supplied Dockerfile builds a production container you can use to run pruvious on most container runtimes.
-As of the time of writing, Docker, Docker Swarm and Kubernetes (containerd) have been tested.
+This guide provides a quick overview and general guidelines on how to deploy your Pruvious instance using Docker.
 
-Some basic knowledge of docker and docker-compose is expected throughout this guide.
-If you want to learn more about docker and compose feel free to check out the docker documentation at https://docs.docker.com/get-started/docker-overview/.
+The supplied Dockerfile builds a production container you can use to run Pruvious on most container runtimes.
+As of the time of writing, Docker, Docker Swarm, and Kubernetes (containerd) have been tested and confirmed working.
 
+Some basic knowledge of Docker and docker-compose is expected throughout this guide.
+If you want to learn more about Docker and Compose, please check out the official Docker documentation at https://docs.docker.com/get-started/docker-overview/.
 
-# 1. Building the docker image
+## 1. Building the docker image
 
-## Prerequisites
+### Prerequisites
 
-    Ensure that you have Docker installed on your machine.
+- Ensure that you have Docker installed on your machine.
+- Make sure you have the latest version of your Pruvious project code.
 
 ### Building the image
 
@@ -22,39 +24,63 @@ To build the Docker image, run the following command in the root of your project
 ```bash
 docker build -t pruvious-app .
 ```
-This will create a Docker image with the tag `pruvious-app` on your local machine. You can change this tag if you like, but make sure to change it in the supplied docker-compose files.
-If you plan on running the image on another machine than the one you built it on, please consider pushing the image to a container registry like docker hub.
 
-# 2. Deploying via Portainer/Docker-Compose
+This will create a Docker image with the tag `pruvious-app` on your local machine. You can change this tag if you prefer, but make sure to update it in the supplied docker-compose files if you do.
 
-The supplied docker-compose files in the `/docker` directory are supposed to be a starting point to get you up and running with your image.
+If you plan on running the image on a different machine than the one you built it on, consider pushing the image to a container registry like Docker Hub.
 
-## Option 1: Local Build (easy way)
-Have docker-compose automatically build an image from your current repository, and use that in the deployment.
-This is the easiest way to deploy pruvious with a database on a system.
+## 2. Deploying via Portainer/Docker-Compose
 
-### Step 1: Copy /docker/docker-compose.yml to /
-Copy the docker-compose.yml to your repository root (run from the root directory of you repository):
+The supplied docker-compose files in the `/docker` directory are intended to be a starting point to get you up and running with your image.
+
+### Option 1: Local Build (easy way)
+
+Have docker-compose automatically build an image from your current repository and use that in the deployment.
+This is the easiest way to deploy Pruvious with a database on a single system.
+
+#### Step 1: Copy /docker/docker-compose.yml to /
+
+Copy the docker-compose.yml to your repository root (run from the root directory of your repository):
+
 ```bash
 cp ./docker/docker-compose.yml ./
 ```
 
-### Step 2: Run docker-compose to build and deploy
-Make sure you are using compose v2 when running this
+#### Step 2: Run docker-compose to build and deploy
+
+Make sure you are using Compose v2 when running this command:
+
 ```bash
 docker compose up --build
 ```
-If above command does not work, you might still be using compose v1. Run the following instead:
+
+If the above command does not work, you might still be using Compose v1. In that case, run the following instead:
+
 ```bash
 docker-compose up --build
 ```
 
-### Congrats
-You should now see a pruvious instance with all of your blocks on port 3000 :)
+You should now see a Pruvious instance with all of your blocks running on port 3000.
 
+To access your application, open a web browser and navigate to `http://localhost:3000`.
 
-## Option 2: Docker Swarm with traefik (hard)
+### Option 2: Docker Swarm with Traefik (advanced)
+
 See `/docker/docker-compose.traefik.yml`
 
-This option mainly exists to showcase how we (onesrv.net) have deployed pruvious in production and provide a starting point for people who are looking to deploy in a similar environment.
-If you are reading this, you probably know your fair share of docker and other tools. Going into detail on swarm, traefik and portainer would be too much for here.
+This option mainly exists to showcase how we (onesrv.net) have deployed Pruvious in production and provide a starting point for people who are looking to deploy in a similar environment.
+
+If you're considering this option, you likely have experience with Docker and related tools. Detailed explanations of Swarm, Traefik, and Portainer are beyond the scope of this guide, but here are some key points to consider:
+
+- Ensure your Swarm cluster is properly set up and configured.
+- Adjust the Traefik labels in the docker-compose file to match your domain and SSL certificate settings.
+- Review and modify network configurations as needed for your environment.
+
+## Troubleshooting
+
+If you encounter issues during deployment, try the following:
+
+1. Check Docker logs: `docker logs <container_name>`
+2. Ensure all required ports are open and not conflicting with other services.
+3. Verify that the database connection string in the environment variables is correct.
+4. For Swarm deployments, check that all nodes in the cluster are healthy and communicating properly.

--- a/docker/docker-compose.traefik.yml
+++ b/docker/docker-compose.traefik.yml
@@ -1,40 +1,45 @@
-# This file can be used as a starting point for deploying a built pruvious container
-# in a docker swarm cluster with traefik as the loadbalancer.
-# We (onesrv.net) use this in production, but cannot guarantee that this will work for your
-# cluster right out of the box as it depends on how you installed and setup traefik
+# Docker Compose file for deploying a built Pruvious container in a Docker Swarm cluster with Traefik as the load balancer
+# Note: This configuration is based on onesrv.net's production setup and may require adjustments for your specific environment
+
 version: '3'
 services:
   nuxt:
-    # Make sure to replace this with the pruvious image you have built before!
-    # How to build a docker image: https://docs.docker.com/get-started/workshop/02_our_app/
+    # Replace this with your built Pruvious Docker image
+    # For instructions on building Docker images, visit: https://docs.docker.com/get-started/workshop/02_our_app/
     image: <REPLACE:your-docker-image>:latest
     restart: unless-stopped
     deploy:
       replicas: 1
       labels:
+        # Traefik configuration for HTTP
         - traefik.http.routers.pruvious-http.rule=Host(`<yourdomain.com>`)
         - traefik.http.routers.pruvious-http.entrypoints=web
 
+        # Traefik configuration for HTTPS
         - traefik.http.routers.pruvious.rule=Host(`<yourdomain.com>`)
         - traefik.http.routers.pruvious.entrypoints=websecure
         - traefik.http.routers.pruvious.tls
-        # Our letsencrypt cert resolver is called le, change name if needed
+        # Specify the Let's Encrypt certificate resolver (change 'le' if your resolver has a different name)
         - traefik.http.routers.pruvious.tls.certResolver=le
-        -
+
+        # Specify the port your Nuxt app is running on (default is 3000)
         - traefik.http.services.pruvious-service.loadbalancer.server.port=3000
         - traefik.constraint-label=traefik-public
         - traefik.enable=true
     environment:
+      # Database connection string - adjust if necessary
       - NUXT_PRUVIOUS_DATABASE=postgresql://pruvious:pruvious@db:5432/pruvious
     volumes:
       - uploads:/app/uploads
     networks:
       - traefik-public
       - internal
+
   db:
     image: postgres:15-alpine
     restart: always
-    #    command: ["postgres", "-c", "config_file=/var/lib/postgresql/data/postgresql.conf"]
+    # Uncomment the following line if you need to specify a custom PostgreSQL configuration file
+    #command: ["postgres", "-c", "config_file=/var/lib/postgresql/data/postgresql.conf"]
     environment:
       - POSTGRES_USER=pruvious
       - POSTGRES_PASSWORD=pruvious
@@ -46,13 +51,15 @@ services:
       - internal
 
 networks:
+  # External network for Traefik communication
   traefik-public:
     external: true
+  # Internal network for service-to-service communication
   internal:
 
-
-# MAKE SURE TO CHANGE THESE VOLUMES TO YOUR PREFERED VOLUME DRIVER! (Please see docker docs or use the standard docker-compose.yml
-# if you do not know what to do here!
+# Volume configuration
+# IMPORTANT: Adjust these volume definitions according to your preferred volume driver
+# If you're unsure, consider using the standard docker-compose.yml or refer to Docker documentation
 volumes:
   db:
   uploads:

--- a/docker/docker-compose.traefik.yml
+++ b/docker/docker-compose.traefik.yml
@@ -1,0 +1,58 @@
+# This file can be used as a starting point for deploying a built pruvious container
+# in a docker swarm cluster with traefik as the loadbalancer.
+# We (onesrv.net) use this in production, but cannot guarantee that this will work for your
+# cluster right out of the box as it depends on how you installed and setup traefik
+version: '3'
+services:
+  nuxt:
+    # Make sure to replace this with the pruvious image you have built before!
+    # How to build a docker image: https://docs.docker.com/get-started/workshop/02_our_app/
+    image: <REPLACE:your-docker-image>:latest
+    restart: unless-stopped
+    deploy:
+      replicas: 1
+      labels:
+        - traefik.http.routers.pruvious-http.rule=Host(`<yourdomain.com>`)
+        - traefik.http.routers.pruvious-http.entrypoints=web
+
+        - traefik.http.routers.pruvious.rule=Host(`<yourdomain.com>`)
+        - traefik.http.routers.pruvious.entrypoints=websecure
+        - traefik.http.routers.pruvious.tls
+        # Our letsencrypt cert resolver is called le, change name if needed
+        - traefik.http.routers.pruvious.tls.certResolver=le
+        -
+        - traefik.http.services.pruvious-service.loadbalancer.server.port=3000
+        - traefik.constraint-label=traefik-public
+        - traefik.enable=true
+    environment:
+      - NUXT_PRUVIOUS_DATABASE=postgresql://pruvious:pruvious@db:5432/pruvious
+    volumes:
+      - uploads:/app/uploads
+    networks:
+      - traefik-public
+      - internal
+  db:
+    image: postgres:15-alpine
+    restart: always
+    #    command: ["postgres", "-c", "config_file=/var/lib/postgresql/data/postgresql.conf"]
+    environment:
+      - POSTGRES_USER=pruvious
+      - POSTGRES_PASSWORD=pruvious
+      - POSTGRES_DB=pruvious
+      - PGDATA=/var/lib/postgresql/data
+    volumes:
+      - db:/var/lib/postgresql/data/
+    networks:
+      - internal
+
+networks:
+  traefik-public:
+    external: true
+  internal:
+
+
+# MAKE SURE TO CHANGE THESE VOLUMES TO YOUR PREFERED VOLUME DRIVER! (Please see docker docs or use the standard docker-compose.yml
+# if you do not know what to do here!
+volumes:
+  db:
+  uploads:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3'
+services:
+
+  nuxt:
+    # This dockerfile will automatically build an image from your repositoru
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    deploy:
+      replicas: 1
+    environment:
+      - NUXT_PRUVIOUS_DATABASE=postgresql://pruvious:pruvious@db:5432/pruvious
+    volumes:
+      - # Make sure to set a path where you want to store your uploads
+      - <CHANGE TO WHERE YOU WANNA STORE YOUR UPLOADS>:/app/uploads
+    networks:
+      - 3000:3000
+  db:
+    image: postgres:16-alpine
+    restart: always
+    #    command: ["postgres", "-c", "config_file=/var/lib/postgresql/data/postgresql.conf"]
+    environment:
+      - POSTGRES_USER=pruvious
+      - POSTGRES_PASSWORD=pruvious
+      - POSTGRES_DB=pruvious
+      - PGDATA=/var/lib/postgresql/data/
+    volumes:
+      - # Make sure to set a path where you want postgres to store your database data
+      - <CHANGE TO A PATH WHERE YOU WANT TO STORE YOU DB FILES>:/var/lib/postgresql/data/
+    ports:
+      - 5432:5432
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,8 +1,7 @@
 version: '3'
 services:
-
   nuxt:
-    # This dockerfile will automatically build an image from your repositoru
+    # Build the Nuxt application using the Dockerfile in the current directory
     build:
       context: .
       dockerfile: Dockerfile
@@ -10,24 +9,27 @@ services:
     deploy:
       replicas: 1
     environment:
+      # Database connection string for Pruvious
       - NUXT_PRUVIOUS_DATABASE=postgresql://pruvious:pruvious@db:5432/pruvious
     volumes:
-      - # Make sure to set a path where you want to store your uploads
-      - <CHANGE TO WHERE YOU WANNA STORE YOUR UPLOADS>:/app/uploads
+      # Mount point for uploads. Replace <PATH_TO_UPLOADS> with your desired local path
+      - <PATH_TO_UPLOADS>:/app/uploads
     networks:
+      # Expose the Nuxt application on port 3000
       - 3000:3000
   db:
     image: postgres:16-alpine
     restart: always
-    #    command: ["postgres", "-c", "config_file=/var/lib/postgresql/data/postgresql.conf"]
+    # Uncomment the following line to use a custom PostgreSQL configuration file
+    # command: ["postgres", "-c", "config_file=/var/lib/postgresql/data/postgresql.conf"]
     environment:
       - POSTGRES_USER=pruvious
       - POSTGRES_PASSWORD=pruvious
       - POSTGRES_DB=pruvious
       - PGDATA=/var/lib/postgresql/data/
     volumes:
-      - # Make sure to set a path where you want postgres to store your database data
-      - <CHANGE TO A PATH WHERE YOU WANT TO STORE YOU DB FILES>:/var/lib/postgresql/data/
+      # Mount point for PostgreSQL data. Replace <PATH_TO_DB_DATA> with your desired local path
+      - <PATH_TO_DB_DATA>:/var/lib/postgresql/data/
     ports:
+      # Expose PostgreSQL on port 5432
       - 5432:5432
-


### PR DESCRIPTION
Hey, as promised in #https://github.com/pruvious/pruvious/issues/51#issuecomment-2323297054 here is my proposal for some docker related stuff.
This PR includes:
 - Dockerfile to build a somewhat optimized production container
 - /docker directory with
   - a docker-compose.yml to use a locally built image
   - a docker-compose.traefik.yml file that is an example for a production docker setup (using traefik as a reverse proxy) 
   - a small Guide on how to use the files
   
Feel free to make changes to this where needed (I didn't sanity check some of the comments I wrote :p)