### PR TITLE
Be able to create non-admin user as a non-admin user with Create Users capability

### DIFF
--- a/src/runtime/collections/standard/users.collection.ts
+++ b/src/runtime/collections/standard/users.collection.ts
@@ -117,7 +117,7 @@ export default defineCollection({
       additional: {
         guards: [
           async ({ cache, currentQuery, language, operation, value }) => {
-            if (operation === 'create') {
+            if (operation === 'create' && value) {
               throw new Error(__(language, 'pruvious-server', 'You are not authorized to create admin users'))
             }
 


### PR DESCRIPTION
Currently, a non-admin user with Create User capability cannot create another user.
It's getting `You are not authorized to create admin users` regardless of the value of isAdmin.

Added a missing check in the `user.isAdmin` guard to not throw if the value is `false`.