### PR TITLE
fix(blocks): filter and don't pass empty slots to block components (#82)

### DIFF
--- a/src/runtime/components/misc/Blocks.vue
+++ b/src/runtime/components/misc/Blocks.vue
@@ -22,7 +22,9 @@
       :isPreset="isPreset"
     >
       <template
-        v-for="(childBlocks, slotName) in block.slots"
+        v-for="([slotName, childBlocks]) in Object
+          .entries(block.slots ?? {})
+          .filter(([_slot, blocks]) => Boolean((blocks as any[])?.length))"
         :key="`${keyPrefix}.${i}.block.slots.${slotName}`"
         #[slotName]
       >


### PR DESCRIPTION
Fixes pruvious/pruvious#82
In `<template></template>` section of block component `$slots.['block-slot-name']` will be `undefined` if no child blocks passed to the block slot. See original issue for details.