### PR TITLE
feat/better-clipboard

### DIFF
--- a/src/runtime/components/misc/CollectionsContentRecord.vue
+++ b/src/runtime/components/misc/CollectionsContentRecord.vue
@@ -361,7 +361,12 @@ import { useEventListener } from '@vueuse/core'
 import { useSortable } from '@vueuse/integrations/useSortable'
 import { nanoid } from 'nanoid'
 import { debounce } from 'perfect-debounce'
-import { copyToClipboard, usePruviousClipboard } from '../../composables/dashboard/clipboard'
+import {
+  copyToClipboard,
+  setClipboardState,
+  useClipboardText,
+  usePruviousClipboard,
+} from '../../composables/dashboard/clipboard'
 import { useCollectionLanguage } from '../../composables/dashboard/collection-language'
 import { confirmClick, useClickConfirmation } from '../../composables/dashboard/confirm-click'
 import { navigateToPruviousDashboardPath, usePruviousDashboard } from '../../composables/dashboard/dashboard'
@@ -491,6 +496,16 @@ if (previewResponse.success) {
 
 useHead({ title })
 
+useEventListener(window, 'paste', (event) => {
+  if (blockFocused.value && selectedBlock.value) {
+    const text = useClipboardText(event)
+    if (text) {
+      setClipboardState(text)
+      pasteBlockAfter(selectedBlock.value)
+    }
+  }
+})
+
 useEventListener('keydown', (event) => {
   const action = getHotkeyAction(event)
 
@@ -513,10 +528,6 @@ useEventListener('keydown', (event) => {
         cutBlock(selectedBlock.value)
       } else {
         return
-      }
-    } else if (action === 'paste') {
-      if (blockFocused.value && selectedBlock.value) {
-        pasteBlockAfter(selectedBlock.value)
       }
     } else if (action === 'delete') {
       if (blockFocused.value && selectedBlock.value) {
@@ -972,7 +983,10 @@ useEventListener(window, 'message', async (event) => {
         }
         break
       case 'pruvious:paste':
+        console.log('paste')
         if (selectedBlock.value) {
+          const { text } = event.data.data as { text: string }
+          setClipboardState(text)
           pasteBlockAfter(selectedBlock.value)
         }
         break

--- a/src/runtime/components/misc/Preview.vue
+++ b/src/runtime/components/misc/Preview.vue
@@ -25,6 +25,7 @@ import { __, loadTranslatableStrings } from '../../composables/translatable-stri
 import { isArray } from '../../utils/array'
 import { pruviousFetch } from '../../utils/fetch'
 import { isKeyOf, isObject } from '../../utils/object'
+import { useClipboardText } from '../../composables/dashboard/clipboard'
 
 const page = usePage()
 const route = useRoute()
@@ -126,6 +127,13 @@ if (process.client) {
     useEventListener(window, 'focus', () => messageParent('focus'))
     useEventListener(window, 'blur', () => messageParent('blur'))
 
+    useEventListener(window, 'paste', (e) => {
+      const text = useClipboardText(e)
+      if (text) {
+        messageParent('paste', { text })
+      }
+    })
+
     useEventListener('keydown', (event) => {
       const action = getHotkeyAction(event)
 
@@ -140,8 +148,6 @@ if (process.client) {
           messageParent('copy')
         } else if (action === 'cut') {
           messageParent('cut')
-        } else if (action === 'paste') {
-          messageParent('paste')
         } else if (action === 'delete') {
           messageParent('delete')
         } else if (action === 'duplicate') {

--- a/src/runtime/composables/dashboard/clipboard.ts
+++ b/src/runtime/composables/dashboard/clipboard.ts
@@ -32,6 +32,7 @@ useEventListener('focus', checkClipboard)
 useEventListener('pruvious-copy' as any, checkClipboard)
 
 async function checkClipboard() {
+  return
   try {
     const value = JSON.parse(await navigator.clipboard.readText())
 

--- a/src/runtime/composables/dashboard/clipboard.ts
+++ b/src/runtime/composables/dashboard/clipboard.ts
@@ -17,30 +17,44 @@ export const usePruviousClipboard: () => Ref<PruviousClipboard | null> = () =>
 
 /**
  * Copy something to the clipboard.
+ * Also keeps the pruvious clipboard state in sync.
  */
 export async function copyToClipboard(type: PruviousClipboard['pruviousClipboardType'], payload: any) {
+  const text = JSON.stringify({ pruviousClipboardType: type, payload })
+  setClipboardState(text)
+
   await navigator.clipboard
-    .writeText(JSON.stringify({ pruviousClipboardType: type, payload }))
+    .writeText(text)
     .then(() => pruviousToasterShow({ message: __('pruvious-dashboard', 'Copied') }))
     .catch((error) => pruviousToasterShow({ message: error.toString(), type: 'error' }))
-
-  await checkClipboard()
 }
 
-useEventListener('copy', checkClipboard)
-useEventListener('focus', checkClipboard)
-useEventListener('pruvious-copy' as any, checkClipboard)
+/**
+ * Set the pruvious clipboard state from a string.
+ * Called when:
+ *  - writing to the clipboard (to keep the in-app clipboard state in sync)
+ *  - receiving a paste event from an external source
+ * @param text 
+ */
+export function setClipboardState(text: string) {
+  const value = JSON.parse(text)
 
-async function checkClipboard() {
-  return
-  try {
-    const value = JSON.parse(await navigator.clipboard.readText())
+  if (value.pruviousClipboardType) {
+    usePruviousClipboard().value = value
+  }
+}
 
-    if (value.pruviousClipboardType) {
-      usePruviousClipboard().value = value
-      return
-    }
-  } catch {}
+/**
+ * Override the default paste behavior.
+ * Get the clipboard text from a paste event and prevent the default action.
+ * @param e 
+ */
+export function useClipboardText(e: ClipboardEvent) {
+  const text = e.clipboardData?.getData('text/plain')
 
-  usePruviousClipboard().value = null
+  if (text) {
+    e.preventDefault()
+  }
+
+  return text
 }

--- a/src/runtime/composables/dashboard/hotkeys.ts
+++ b/src/runtime/composables/dashboard/hotkeys.ts
@@ -102,10 +102,6 @@ export function getHotkeyAction(event: KeyboardEvent): HotkeyAction | null {
       window.dispatchEvent(new CustomEvent('pruvious-copy'))
       return 'cut'
     }
-  } else if (letter === 'v') {
-    if (!event.shiftKey && !isEditingText()) {
-      return 'paste'
-    }
   } else if (letter === 's') {
     if (!event.shiftKey) {
       return 'save'

--- a/src/runtime/directives/vOnPaste.ts
+++ b/src/runtime/directives/vOnPaste.ts
@@ -1,0 +1,42 @@
+import type { DirectiveBinding } from "#imports"
+
+interface PastingHTMLElement extends HTMLElement {
+  pasteTarget?: HTMLElement
+}
+
+type OnPasteCallback = (event: ClipboardEvent) => void
+
+export const vOnPaste = {
+  mounted(el: PastingHTMLElement, binding: DirectiveBinding<OnPasteCallback>) {
+    const target = document.createElement('div')
+    target.contentEditable = 'true'
+    target.style.position = 'absolute'
+    target.style.top = '0'
+    target.style.left = '0'
+    target.style.width = '0'
+    target.style.height = '0'
+    target.style.opacity = '0'
+
+    target.addEventListener('paste', (event) => {
+      event.preventDefault()
+      event.stopPropagation()
+      binding.value(event)
+    })
+
+    el.pasteTarget = target
+    el.appendChild(target)
+
+    el.addEventListener('keydown', (_) => {
+      target.focus()
+    })
+
+    el.addEventListener('contextmenu', (_) => {
+      target.focus()
+    })
+  },
+  unmounted(el: PastingHTMLElement) {
+    if (el.pasteTarget) {
+      el.pasteTarget.remove()
+    }
+  }
+}


### PR DESCRIPTION
Replaces the old clipboard API based copy/paste with listening to the `paste` event on `window`.
No longer triggers clipboard permissions popups.

Fixes #66 