### PR TITLE
Naming resolver for pruvious specific files.

### DIFF
--- a/packages/pruvious/modules/pruvious/collections/resolver.ts
+++ b/packages/pruvious/modules/pruvious/collections/resolver.ts
@@ -4,7 +4,7 @@ import { useNuxt } from 'nuxt/kit'
 import type { NuxtConfigLayer } from 'nuxt/schema'
 import { relative } from 'pathe'
 import { debug, warnWithContext } from '../debug/console'
-import { resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
+import { normalizeSegments, reduceFileNameSegments, resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
 
 /**
  * Key-value object containing collection names and their definition file locations.
@@ -30,7 +30,7 @@ export function resolveCollectionFiles(): Record<string, ResolveFromLayersResult
         debug(`Resolving collections in layer <${relative(nuxt.options.workspaceDir, layer.cwd) || '.'}>`),
     })) {
       const { layer, file, base, pruviousDirNames } = location
-      const collectionName = pascalCase(pruviousDirNames.join('-') + '-' + base)
+      const collectionName = pascalCase(normalizeSegments(reduceFileNameSegments(pruviousDirNames, base)))
       const slug = slugify(collectionName)
 
       if (isDefined(duplicates[collectionName]) && duplicates[collectionName].layer === layer) {

--- a/packages/pruvious/modules/pruvious/fields/resolver.ts
+++ b/packages/pruvious/modules/pruvious/fields/resolver.ts
@@ -3,7 +3,12 @@ import { useNuxt } from 'nuxt/kit'
 import type { NuxtConfigLayer } from 'nuxt/schema'
 import { relative } from 'pathe'
 import { debug, warnWithContext } from '../debug/console'
-import { normalizeSegments, reduceFileNameSegments, resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
+import {
+  normalizeSegments,
+  reduceFileNameSegments,
+  resolveFromLayers,
+  type ResolveFromLayersResult,
+} from '../utils/resolve'
 
 type FieldComponents = Record<string, { regular?: ResolveFromLayersResult; table?: ResolveFromLayersResult }>
 
@@ -80,7 +85,7 @@ export function resolveFieldComponentFiles(): FieldComponents {
     })) {
       const { layer, file, base, pruviousDirNames } = location
       const type: 'regular' | 'table' = base.endsWith('.table') ? 'table' : 'regular'
-      const slug = pruviousDirNames.join('-') + '-' + base.replace(/\.(?:regular|table)$/, '')
+      const slug = normalizeSegments(reduceFileNameSegments(pruviousDirNames, base.replace(/\.(?:regular|table)$/, '')))
       const fieldName =
         pruviousDirNames[0] && ['collections', 'singletons'].includes(pruviousDirNames[0])
           ? slug.replaceAll('-', '/')

--- a/packages/pruvious/modules/pruvious/fields/resolver.ts
+++ b/packages/pruvious/modules/pruvious/fields/resolver.ts
@@ -3,7 +3,7 @@ import { useNuxt } from 'nuxt/kit'
 import type { NuxtConfigLayer } from 'nuxt/schema'
 import { relative } from 'pathe'
 import { debug, warnWithContext } from '../debug/console'
-import { resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
+import { normalizeSegments, reduceFileNameSegments, resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
 
 type FieldComponents = Record<string, { regular?: ResolveFromLayersResult; table?: ResolveFromLayersResult }>
 
@@ -36,7 +36,7 @@ export function resolveFieldDefinitionFiles(): Record<string, ResolveFromLayersR
         debug(`Resolving field definitions in layer <${relative(nuxt.options.workspaceDir, layer.cwd) || '.'}>`),
     })) {
       const { layer, file, base, pruviousDirNames } = location
-      const fieldName = camelCase(pruviousDirNames.join('-') + '-' + base)
+      const fieldName = camelCase(normalizeSegments(reduceFileNameSegments(pruviousDirNames, base)))
 
       if (isDefined(duplicates[fieldName]) && duplicates[fieldName].layer === layer) {
         warnWithContext(`Two field definition files resolving to the same name \`${fieldName}\`:`, [

--- a/packages/pruvious/modules/pruvious/hooks/resolver.ts
+++ b/packages/pruvious/modules/pruvious/hooks/resolver.ts
@@ -5,7 +5,7 @@ import type { NuxtConfigLayer } from 'nuxt/schema'
 import { join, relative } from 'pathe'
 import { debug, warnWithContext } from '../debug/console'
 import { extractStringLiteralArguments } from '../utils/ast'
-import { resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
+import { reduceFileNameSegments, resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
 
 /**
  * Key-value object containing action names and their definition file locations for both client and server.
@@ -80,7 +80,7 @@ export function resolveActionDefinitionFiles(): {
         ),
     })) {
       const { layer, file, base, pruviousDirNames } = location
-      const actionName = [...pruviousDirNames, base].map(kebabCase).join(':')
+      const actionName = reduceFileNameSegments(pruviousDirNames, base).map(kebabCase).join(':')
 
       if (isDefined(duplicates[actionName]) && duplicates[actionName].layer === layer) {
         warnWithContext(`Two client-side action definition files resolving to the same name \`${actionName}\`:`, [

--- a/packages/pruvious/modules/pruvious/hooks/resolver.ts
+++ b/packages/pruvious/modules/pruvious/hooks/resolver.ts
@@ -117,7 +117,7 @@ export function resolveActionDefinitionFiles(): {
         ),
     })) {
       const { layer, file, base, pruviousDirNames } = location
-      const actionName = [...pruviousDirNames, base].map(kebabCase).join(':')
+      const actionName = reduceFileNameSegments(pruviousDirNames, base).map(kebabCase).join(':')
 
       if (isDefined(duplicates[actionName]) && duplicates[actionName].layer === layer) {
         warnWithContext(`Two server-side action definition files resolving to the same name \`${actionName}\`:`, [
@@ -170,7 +170,7 @@ export function resolveFilterDefinitionFiles(): {
         ),
     })) {
       const { layer, file, base, pruviousDirNames } = location
-      const filterName = [...pruviousDirNames, base].map(kebabCase).join(':')
+      const filterName = reduceFileNameSegments(pruviousDirNames, base).map(kebabCase).join(':')
 
       if (isDefined(duplicates[filterName]) && duplicates[filterName].layer === layer) {
         warnWithContext(`Two client-side filter definition files resolving to the same name \`${filterName}\`:`, [
@@ -207,7 +207,7 @@ export function resolveFilterDefinitionFiles(): {
         ),
     })) {
       const { layer, file, base, pruviousDirNames } = location
-      const filterName = [...pruviousDirNames, base].map(kebabCase).join(':')
+      const filterName = reduceFileNameSegments(pruviousDirNames, base).map(kebabCase).join(':')
 
       if (isDefined(duplicates[filterName]) && duplicates[filterName].layer === layer) {
         warnWithContext(`Two server-side filter definition files resolving to the same name \`${filterName}\`:`, [

--- a/packages/pruvious/modules/pruvious/queue/resolver.ts
+++ b/packages/pruvious/modules/pruvious/queue/resolver.ts
@@ -3,7 +3,7 @@ import { useNuxt } from 'nuxt/kit'
 import type { NuxtConfigLayer } from 'nuxt/schema'
 import { relative } from 'pathe'
 import { debug, warnWithContext } from '../debug/console'
-import { resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
+import { normalizeSegments, reduceFileNameSegments, resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
 
 /**
  * Key-value object containing job names and their definition file locations.
@@ -29,7 +29,7 @@ export function resolveJobFiles(): Record<string, ResolveFromLayersResult> {
         debug(`Resolving jobs in layer <${relative(nuxt.options.workspaceDir, layer.cwd) || '.'}>`),
     })) {
       const { layer, file, base, pruviousDirNames } = location
-      const jobName = kebabCase(pruviousDirNames.join('-') + '-' + base)
+      const jobName = kebabCase(normalizeSegments(reduceFileNameSegments(pruviousDirNames, base)))
 
       if (isDefined(duplicates[jobName]) && duplicates[jobName].layer === layer) {
         warnWithContext(`Two job files resolving to the same name \`${jobName}\`:`, [

--- a/packages/pruvious/modules/pruvious/singletons/resolver.ts
+++ b/packages/pruvious/modules/pruvious/singletons/resolver.ts
@@ -3,7 +3,7 @@ import { useNuxt } from 'nuxt/kit'
 import type { NuxtConfigLayer } from 'nuxt/schema'
 import { relative } from 'pathe'
 import { debug, warnWithContext } from '../debug/console'
-import { resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
+import { normalizeSegments, reduceFileNameSegments, resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
 
 /**
  * Key-value object containing singleton names and their definition file locations.
@@ -29,7 +29,7 @@ export function resolveSingletonFiles(): Record<string, ResolveFromLayersResult>
         debug(`Resolving singletons in layer <${relative(nuxt.options.workspaceDir, layer.cwd) || '.'}>`),
     })) {
       const { layer, file, base, pruviousDirNames } = location
-      const singletonName = pascalCase(pruviousDirNames.join('-') + '-' + base)
+      const singletonName = pascalCase(normalizeSegments(reduceFileNameSegments(pruviousDirNames, base)))
       const slug = slugify(singletonName)
 
       if (isDefined(duplicates[singletonName]) && duplicates[singletonName].layer === layer) {

--- a/packages/pruvious/modules/pruvious/templates/resolver.ts
+++ b/packages/pruvious/modules/pruvious/templates/resolver.ts
@@ -3,7 +3,7 @@ import { useNuxt } from 'nuxt/kit'
 import type { NuxtConfigLayer } from 'nuxt/schema'
 import { relative } from 'pathe'
 import { debug, warnWithContext } from '../debug/console'
-import { resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
+import { normalizeSegments, reduceFileNameSegments, resolveFromLayers, type ResolveFromLayersResult } from '../utils/resolve'
 
 /**
  * Key-value object containing template names and their definition file locations.
@@ -29,7 +29,7 @@ export function resolveTemplateFiles(): Record<string, ResolveFromLayersResult> 
         debug(`Resolving templates in layer <${relative(nuxt.options.workspaceDir, layer.cwd) || '.'}>`),
     })) {
       const { layer, file, base, pruviousDirNames } = location
-      const templateName = pascalCase(pruviousDirNames.join('-') + '-' + base)
+      const templateName = pascalCase(normalizeSegments(reduceFileNameSegments(pruviousDirNames, base)))
 
       if (isDefined(duplicates[templateName]) && duplicates[templateName].layer === layer) {
         warnWithContext(`Two template files resolving to the same name \`${templateName}\`:`, [


### PR DESCRIPTION
Tried creating a collection at `/server/collections/calendar/calendar.ts` which resulted in the collection name being `CalendarCalendar`

How the name resolution currently is working:
`collections/calendar/calendar.ts` -> `CalendarCalendar`
`collections/calendar/event.ts` -> `CalendarEvent`

So my proposal is to simulate how nuxt handle component names that im guessing most people are familiar with.

After the proposed changes:
`collections/calendar/calendar.ts` -> `Calendar`
`collections/calendar/event.ts` -> `CalendarEvent`

It resolves the collectionName in https://github.com/pruvious/pruvious/blob/v4/packages/pruvious/modules/pruvious/collections/resolver.ts#L33

---

Available resolvers:

1. Collections
File: packages/pruvious/modules/pruvious/collections/resolver.ts
Should work just like you explained.

2. Fields (field types)
File: packages/pruvious/modules/pruvious/collections/resolver.ts
Same as collections, just in camelCase.

3. Templates
File: packages/pruvious/modules/pruvious/templates/resolver.ts
Same as collections (PascalCase).

4. Queue
File: packages/pruvious/modules/pruvious/queue/resolver.ts
Same, but kebab-case.

5. Singletons
File: packages/pruvious/modules/pruvious/singletons/resolver.ts
Same as collections (PascalCase).

6. API
File: packages/pruvious/modules/pruvious/api/resolver.ts
Here we have a slightly different implementation that already converts path/[something]/index to path/:something.

7. Hooks
File: packages/pruvious/modules/pruvious/hooks/resolver.ts
Names are resolved for actions and filters. They have the format [...dir, file].map(kebabCase).join(':'). Maybe index.ts can be introduced here to pop the file name. Otherwise, we need to keep allowing chaining of dir names here (foo:foo should be a valid hook name).

8. Translations
File: packages/pruvious/modules/pruvious/translations/resolver.ts
I think we should leave this one as it is.

9. Custom components
File: packages/pruvious/modules/pruvious/components/resolver.ts
This is a different type of resolver that should remain unchanged.

---

It does not match exactly how nuxt does it with component names (Nuxt matches the kebab cased segments)
The difference is that pluralization is accepted during the reduction for non-mind melting logic.

reduceFileNameSegments - takes an array of segments and optional baseName which returns a reduced array.
normalizeSegments - maps array and kebabifies each segment and joins with `-`

The functions are split due to a personal dislike for the array hell in normalizeSegments.

In the end it can be wrapped by one of the casing functions from @pruvious/utils.

Usage
```ts
const collectionName = pascalCase(normalizeSegments(reduceFileNameSegments(pruviousDirNames, base)))
```


Some examples
```ts
["path","file"] -> 'path-file' // No matches
["path","path","path","file"] -> 'path-file' // Segment is skipped because it fully matches previous segment
["path","pathFile"] -> 'path-file' // Segment starts with previous segment name
["path","pathfile"] -> 'pathfile' // Segment starts with previous segment name
["pathFile","file"] -> 'path-file-file' // A segment has a sub-segmented name
["my","path","myFile"] -> 'my-path-my-file' // A segment has a sub-segmented name
```
